### PR TITLE
copy state on `start!` for local manager

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaBatches"
 uuid = "181bd894-5b11-491a-bec3-9b1779d96000"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"


### PR DESCRIPTION
This adds a small check in `start!` that will copy the initial state if the manager PID is the same as the calling worker.  This fixes #25 (and also adds tests to make sure we can reproduce that behavior)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204515777435058