### PR TITLE
add `samples_eltype` argument to load/materialize functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OndaBatches"
 uuid = "181bd894-5b11-491a-bec3-9b1779d96000"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.4.5"
+version = "0.4.6"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/labeled_signal.jl
+++ b/src/labeled_signal.jl
@@ -65,7 +65,7 @@ function store_labels(labeled_signal::LabeledSignalV2, root; format="lpcm")
 end
 
 """
-    function load_labeled_signal(labeled_signal)
+    function load_labeled_signal(labeled_signal, samples_eltype::Type=Float64)
 
 Load signal data as `Onda.Samples` from a labeled segment of an `Onda.SignalV2` (i.e.,
 a [`LabeledSignalV2`](@ref) or row with schema `"labeled.signal@2"`), and
@@ -74,6 +74,20 @@ along with the corresponding labels (as another `Onda.Samples` object).
 
 If possible, this will only retrieve the bytes corresponding to
 `labeled_signal.label_span`.
+
+The `eltype` of the returned `Samples` is `samples_eltype`, which defaults to
+`Float64`.
+
+!!! note
+
+    The handling of samples `eltype` is different than `Onda.load`, for which
+    the `eltype` depends on the resolution/offset specified in the samples info:
+    when they are 1/0 respectively, the underlying encoded data is _always_
+    returned exactly as-is, even if the type differs from the requested
+    `eltype`.  This allows for some optimizations in such cases, but is a
+    potential footgun when a particular `eltype` is actually required.  We work
+    around this inconsistency here by always allocating a _new_ array with the
+    requested `eltype` to hold the decoded samples.
 
 Returns a `samples, labels` tuple.
 """

--- a/src/materialize_batch.jl
+++ b/src/materialize_batch.jl
@@ -24,7 +24,7 @@ BatchItemV2
 end
 
 """
-    materialize_batch_item(batch_item)
+    materialize_batch_item(batch_item, samples_eltype::Type=Float64)
 
 Load the signal data for a single [`BatchItemV2`](@ref), selecting only the
 channels specified in the `batch_channels` field (using all channels if the
@@ -33,6 +33,9 @@ field is `missing`).
 Returns a `signal_data, label_data` tuple, which is the contents of the `data`
 field of the signals and labels `Samples` objects returned by
 `[load_labeled_signal`](@ref), after the signals data by `batch_channels`.
+
+The eltype of `signal_data` will be `samples_eltype`; the eltype of `label_data`
+is whatever is returned by [`get_labels`](@ref).
 """
 function materialize_batch_item(batch_item, samples_eltype::Type=Float64)
     samples, labels = load_labeled_signal(batch_item, samples_eltype)
@@ -52,12 +55,19 @@ implement more exotic featurization schemes, (see tests for examples).
 get_channel_data(samples::Samples, channels) = samples[channels, :].data
 
 """
-    materialize_batch(batch)
+    materialize_batch(batch, samples_eltype::Type=Float64)
 
 Materialize an entire batch, which is a table of [`BatchItemV2`](@ref) rows.  Each
 row is materialized concurrently by [`materialize_batch_item`](@ref), and the
 resulting signals and labels arrays are concatenated on dimension `ndims(x) + 1`
 respectively.
+
+Returns a `signal_data, label_data` tuple.  The dimensionality of these arrays
+depends on the dimensionality of the results of
+[`materialize_batch_item`](@ref), but will in general be `ndims(x) + 1`.
+
+The eltype of `signal_data` will be `samples_eltype`; the eltype of `label_data`
+is whatever is returned by [`get_labels`](@ref).
 """
 function materialize_batch(batch, samples_eltype::Type=Float64)
     # TODO: check integrity of labeled_signals table for batch construction (are

--- a/test/labeled_signal.jl
+++ b/test/labeled_signal.jl
@@ -381,6 +381,18 @@
                                                          Second(10)))
                           for label in labels]
 
+        @testset "loaded samples eltype" begin
+            x, _ = load_labeled_signal(labeled_signal)
+            x64, _ = load_labeled_signal(labeled_signal, Float64)
+
+            @test x == x64
+            @test eltype(x.data) == eltype(x64.data) == Float64
+
+            x32, _ = load_labeled_signal(labeled_signal, Float32)
+            @test eltype(x32.data) == Float32
+            @test x32.data ≈ x.data
+        end
+
         @testset "aligned to start of recording" begin
             @test labeled_signal.span == labeled_signal.label_span
             samples_rt, _ = load_labeled_signal(labeled_signal)


### PR DESCRIPTION
Fixes #28 

In particular, this works around some idiosyncrasies in how `Onda.load`/`Onda.decode` handle eltypes, by using a `decode!(similar(samples.data, T), samples)` step to ensure that the loaded samples have teh requested eltype `T`.

I consider this a bugfix, so while it may technically be breaking, we've only ever suffered harm in internal Beacon projects from this behavior, so I'm gonna make it a patch release.