### PR TITLE
Remove `AWSS3._s3_exists_dir` piracy

### DIFF
--- a/test/OndaBatchesTests.jl
+++ b/test/OndaBatchesTests.jl
@@ -69,15 +69,6 @@ const labeled_signals = label_signals(uncompressed_signals,
 
 const N_WORKERS = 3
 
-function AWSS3._s3_exists_dir(aws::AWSS3.AbstractAWSConfig, bucket, path)
-    a = chop(string(path)) * "."
-    q = Dict("delimiter" => "", "max-keys" => 1, "start-after" => a, "prefix" => path)
-    l = parse(AWSS3.S3.list_objects_v2(bucket, q; aws_config=aws))
-    c = get(l, "Contents", nothing)
-    c === nothing && return false
-    return startswith(get(c, "Key", ""), path)
-end
-
 # for testing get_channel_data
 struct EvenOdds end
 function OndaBatches.get_channel_data(samples::Samples, channels::EvenOdds)


### PR DESCRIPTION
Follow up to: https://github.com/beacon-biosignals/OndaBatches.jl/pull/32

We don't need to register this change as it's just a change to tests. We may want to backport this change just for consistency.